### PR TITLE
fix(docker): Work around fresh GNU coreutils bombing Docker Hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM archlinux AS casile
+FROM archlinux:20200306 AS casile
+RUN sed -i -e '/IgnorePkg *=/s/^.*$/IgnorePkg = coreutils/' /etc/pacman.conf
 
 # Setup Caleb's hosted Arch repository with prebuilt dependencies
 RUN pacman-key --init && pacman-key --populate


### PR DESCRIPTION
Revert when upstream problem is resolved, see:

https://github.com/archlinux/archlinux-docker/issues/32