### PR TITLE
Let the CLI take charge in Docker, overhaul localization

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Fetch tags
+        run: git fetch --tags
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,6 +59,7 @@ jobs:
           git ls-files '*.rs' | xargs rustfmt --check
 
   cargo_bloat:
+    if: false
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,8 +170,9 @@ dependencies = [
 
 [[package]]
 name = "fluent"
-version = "0.11.0"
-source = "git+https://github.com/projectfluent/fluent-rs#c9e456515f4c084eb9650f3910722a31707a6b32"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3b6132d1377d8776409a337c6851d342aee4e85277c96ecd2755c4e0efde1d"
 dependencies = [
  "fluent-bundle",
  "unic-langid",
@@ -179,8 +180,9 @@ dependencies = [
 
 [[package]]
 name = "fluent-bundle"
-version = "0.11.0"
-source = "git+https://github.com/projectfluent/fluent-rs#c9e456515f4c084eb9650f3910722a31707a6b32"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a094d494ab2ed06077e9a95f4e47f446c376de95f6c93045dd88c499bfcd70"
 dependencies = [
  "fluent-langneg",
  "fluent-syntax",
@@ -193,8 +195,9 @@ dependencies = [
 
 [[package]]
 name = "fluent-fallback"
-version = "0.0.3"
-source = "git+https://github.com/projectfluent/fluent-rs#c9e456515f4c084eb9650f3910722a31707a6b32"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87d8e08eff168fbfd9a897f5c39d840e12a9a1091e274df19010c53855cfa41"
 dependencies = [
  "fluent-bundle",
  "reiterate",
@@ -202,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "fluent-langneg"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5815efd5542e40841cd34ef9003822352b04c67a70c595c6758597c72e1f56"
+checksum = "2c4ad0989667548f06ccd0e306ed56b61bd4d35458d54df5ec7587c0e8ed5e94"
 dependencies = [
  "unic-langid",
 ]
@@ -212,7 +215,8 @@ dependencies = [
 [[package]]
 name = "fluent-syntax"
 version = "0.9.3"
-source = "git+https://github.com/projectfluent/fluent-rs#c9e456515f4c084eb9650f3910722a31707a6b32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac0f7e83d14cccbf26e165d8881dcac5891af0d85a88543c09dd72ebd31d91ba"
 
 [[package]]
 name = "fxhash"
@@ -278,8 +282,9 @@ dependencies = [
 
 [[package]]
 name = "intl-memoizer"
-version = "0.4.0"
-source = "git+https://github.com/projectfluent/fluent-rs#c9e456515f4c084eb9650f3910722a31707a6b32"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0ed58ba6089d49f8a9a7d5e16fc9b9e2019cdf40ef270f3d465fa244d9630b"
 dependencies = [
  "type-map",
  "unic-langid",
@@ -287,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "intl_pluralrules"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82c14d8eece42c03353e0ce86a4d3f97b1f1cef401e4d962dca6c6214a85002"
+checksum = "6c271cdb1f12a9feb3a017619c3ee681f971f270f6757341d6abe1f9f7a98bc3"
 dependencies = [
  "tinystr",
  "unic-langid",
@@ -744,18 +749,18 @@ dependencies = [
 
 [[package]]
 name = "unic-langid"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d81136159f779c35b10655f45210c71cd5ca5a45aadfe9840a61c7071735ed"
+checksum = "73328fcd730a030bdb19ddf23e192187a6b01cd98be6d3140622a89129459ce5"
 dependencies = [
  "unic-langid-impl",
 ]
 
 [[package]]
 name = "unic-langid-impl"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43c61e94492eb67f20facc7b025778a904de83d953d8fcb60dd9adfd6e2d0ea"
+checksum = "1a4a8eeaf0494862c1404c95ec2f4c33a2acff5076f64314b465e3ddae1b934d"
 dependencies = [
  "tinystr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,14 +11,15 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "0.10.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ac5c260f75e4e4ba87b7342be6edcecbcb3eb6741a0507fda7ad115845cc65"
+checksum = "c88b9ca26f9c16ec830350d309397e74ee9abdfd8eb1f71cb6ecc71a3fc818da"
 dependencies = [
- "escargot",
+ "doc-comment",
  "predicates",
  "predicates-core",
  "predicates-tree",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -98,7 +99,8 @@ dependencies = [
 [[package]]
 name = "clap"
 version = "3.0.0-beta.1"
-source = "git+https://github.com/clap-rs/clap#19e3e97544df55bda7f313883aa759df072ca056"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "860643c53f980f0d38a5e25dfab6c3c93b2cb3aa1fe192643d17a293c6c41936"
 dependencies = [
  "atty",
  "bitflags",
@@ -117,7 +119,8 @@ dependencies = [
 [[package]]
 name = "clap_derive"
 version = "3.0.0-beta.1"
-source = "git+https://github.com/clap-rs/clap#19e3e97544df55bda7f313883aa759df072ca056"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb51c9e75b94452505acd21d929323f5a5c6c4735a852adbd39ef5fb1b014f30"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -129,7 +132,8 @@ dependencies = [
 [[package]]
 name = "clap_generate"
 version = "3.0.0-beta.1"
-source = "git+https://github.com/clap-rs/clap#19e3e97544df55bda7f313883aa759df072ca056"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "188d8b137fa922515d549cf17ece165ddbc71bf21e723e81d84406958dcdef67"
 dependencies = [
  "clap",
 ]
@@ -141,22 +145,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "elsa"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0daf12e2857c9485cb2386b18a9ecd5a17c7cee2fd10afb87d436b10ced678e7"
 dependencies = [
  "stable_deref_trait",
-]
-
-[[package]]
-name = "escargot"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19db1f7e74438642a5018cdf263bb1325b2e792f02dd0a3ca6d6c0f0d7b1d5a5"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -294,12 +294,6 @@ dependencies = [
  "tinystr",
  "unic-langid",
 ]
-
-[[package]]
-name = "itoa"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 
 [[package]]
 name = "jobserver"
@@ -610,49 +604,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "serde"
-version = "1.0.106"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.106"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -877,6 +834,15 @@ name = "version_check"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ build = "build.rs"
 fluent = { git = "https://github.com/projectfluent/fluent-rs" }
 fluent-fallback = { git = "https://github.com/projectfluent/fluent-rs" }
 fluent-langneg = "0.12.1"
-# fluent-resmgr = { git = "https://github.com/projectfluent/fluent-rs" }
 git2 = "0.13.5"
 regex = "1.3.7"
 rust-embed = "5.5.1"
@@ -22,18 +21,16 @@ subprocess = "0.2.4"
 unic-langid = "0.8.0"
 
 [dependencies.clap]
-# Unrleleased Clap has integrated structopt
-git = "https://github.com/clap-rs/clap"
-# version = "3.0.0"
-features = ["suggestions", "color", "wrap_help", "derive", "std", "cargo", "unstable"]
+version = "3.0.0-beta.1"
+features = ["wrap_help"]
 
 [build-dependencies]
-clap = { git = "https://github.com/clap-rs/clap" }
-clap_generate = { git = "https://github.com/clap-rs/clap" }
+clap = "3.0.0-beta.1"
+clap_generate = "3.0.0-beta.1"
 vergen = "3.1.0"
 
 [dev-dependencies]
-assert_cmd = "0.10"
+assert_cmd = "1.0.1"
 predicates = "1.0.4"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,15 +10,14 @@ license = "AGPL-3"
 build = "build.rs"
 
 [dependencies]
-# Using Git HEAD because of https://github.com/projectfluent/fluent-rs/issues/175
-fluent = { git = "https://github.com/projectfluent/fluent-rs" }
-fluent-fallback = { git = "https://github.com/projectfluent/fluent-rs" }
-fluent-langneg = "0.12.1"
+fluent = "0.12.0"
+fluent-fallback = "0.0.4"
+fluent-langneg = "0.13.0"
 git2 = "0.13.5"
 regex = "1.3.7"
 rust-embed = "5.5.1"
 subprocess = "0.2.4"
-unic-langid = "0.8.0"
+unic-langid = "0.9.0"
 
 [dependencies.clap]
 version = "3.0.0-beta.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,5 @@ RUN sed -i -e '/pattern="gs"/d' /etc/ImageMagick-7/policy.xml
 LABEL maintainer="Caleb Maclennan <caleb@alerque.com>"
 LABEL version="$VCS_REF"
 
-COPY build-aux/docker-entrypoint.sh /usr/local/bin
-
 WORKDIR /data
-ENTRYPOINT ["docker-entrypoint.sh"]
+ENTRYPOINT ["casile"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /src
 
 RUN ./bootstrap.sh
 RUN ./configure
+RUN make clean
 RUN make
 RUN make install DESTDIR=/pkgdir
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 $(and $(word 2,$(MAKEFILE_LIST)),$(error This is not the makefile you should include in your project to run SILE, please use 'rules' instead.))
 
-_casile != sed -e "$(program_transform_name)" <<< casile
+_casile = $(shell sed -e "$(program_transform_name)" <<< casile)
 
 licensedir = $(datarootdir)/licenses/$(_casile)
 docdir = $(datarootdir)/doc/$(_casile)
@@ -74,17 +74,17 @@ dist_assets_DATA =
 
 if ENABLE_BASH_COMPLETION
 bashcompletiondir = $(BASH_COMPLETION_DIR)
-dist_bashcompletion_DATA = target/release/completions/casile
+dist_bashcompletion_DATA = target/release/completions/$(_casile)
 endif
 
 if ENABLE_FISH_COMPLETION
 fishcompletiondir = $(FISH_COMPLETION_DIR)
-dist_fishcompletion_DATA = target/release/completions/casile.fish
+dist_fishcompletion_DATA = target/release/completions/$(_casile).fish
 endif
 
 if ENABLE_ZSH_COMPLETION
 zshcompletiondir = $(ZSH_COMPLETION_DIR)
-dist_zshcompletion_DATA = target/release/completions/_casile
+dist_zshcompletion_DATA = target/release/completions/_$(_casile)
 endif
 
 if DEBUG_RELEASE
@@ -101,10 +101,17 @@ cargo_verbose_1 = --verbose
 casile$(EXEEXT): target/release/casile
 	cp $< $@
 
-target/release/completions/casile: target/release/casile
-	cp $@.bash $@
+target/release/completions/$(_casile): target/release/completions/casile.bash
+	cp $< $@
+
+target/release/completions/_$(_casile): target/release/completions/_casile
+	cp $< $@
+
+target/release/completions/$(_casile).%: target/release/completions/casile.%
+	cp $< $@
 
 target/release/completions/_casile: target/release/casile
+target/release/completions/casile.bash: target/release/casile
 target/release/completions/casile.elv: target/release/casile
 target/release/completions/casile.fish: target/release/casile
 target/release/completions/casile.ps1: target/release/casile

--- a/Makefile.am
+++ b/Makefile.am
@@ -74,17 +74,17 @@ dist_assets_DATA =
 
 if ENABLE_BASH_COMPLETION
 bashcompletiondir = $(BASH_COMPLETION_DIR)
-dist_bashcompletion_DATA = target/release/completions/$(_casile)
+dist_bashcompletion_DATA = $(COMPLETIONS_OUT_DIR)/$(_casile)
 endif
 
 if ENABLE_FISH_COMPLETION
 fishcompletiondir = $(FISH_COMPLETION_DIR)
-dist_fishcompletion_DATA = target/release/completions/$(_casile).fish
+dist_fishcompletion_DATA = $(COMPLETIONS_OUT_DIR)/$(_casile).fish
 endif
 
 if ENABLE_ZSH_COMPLETION
 zshcompletiondir = $(ZSH_COMPLETION_DIR)
-dist_zshcompletion_DATA = target/release/completions/_$(_casile)
+dist_zshcompletion_DATA = $(COMPLETIONS_OUT_DIR)/_$(_casile)
 endif
 
 if DEBUG_RELEASE
@@ -98,25 +98,28 @@ cargo_verbose_ = $(cargo_verbose_$(AM_DEFAULT_VERBOSITY))
 cargo_verbose_0 =
 cargo_verbose_1 = --verbose
 
-casile$(EXEEXT): target/release/casile
-	cp $< $@
+CARGO_TARGET = target/release/casile
+COMPLETIONS_OUT_DIR = target/release/completions
 
-target/release/completions/$(_casile): target/release/completions/casile.bash
-	cp $< $@
+casile$(EXEEXT): $(CARGO_TARGET)
+	cp -bf $< $@
 
-target/release/completions/_$(_casile): target/release/completions/_casile
-	cp $< $@
+$(COMPLETIONS_OUT_DIR)/$(_casile): $(CARGO_TARGET)
+	cp -bf $(COMPLETIONS_OUT_DIR)/casile.bash $@
 
-target/release/completions/$(_casile).%: target/release/completions/casile.%
-	cp $< $@
+$(COMPLETIONS_OUT_DIR)/$(_casile).elv: $(CARGO_TARGET)
+	cp -bf $(COMPLETIONS_OUT_DIR)/casile.elv $@
 
-target/release/completions/_casile: target/release/casile
-target/release/completions/casile.bash: target/release/casile
-target/release/completions/casile.elv: target/release/casile
-target/release/completions/casile.fish: target/release/casile
-target/release/completions/casile.ps1: target/release/casile
+$(COMPLETIONS_OUT_DIR)/$(_casile).fish: $(CARGO_TARGET)
+	cp -bf $(COMPLETIONS_OUT_DIR)/casile.fish $@
 
-target/release/casile: $(casile_SOURCES) clean-embedded-assets
+$(COMPLETIONS_OUT_DIR)/_$(_casile).ps1: $(CARGO_TARGET)
+	cp -bf $(COMPLETIONS_OUT_DIR)/_casile.ps1 $@
+
+$(COMPLETIONS_OUT_DIR)/_$(_casile): $(CARGO_TARGET)
+	cp -bf $(COMPLETIONS_OUT_DIR)/_casile $@
+
+$(CARGO_TARGET): $(casile_SOURCES) clean-embedded-assets
 	cargo build $(CARGO_VERBOSE) $(CARGO_RELEASE_ARGS)
 
 .PHONY: clean-embedded-assets
@@ -168,6 +171,3 @@ check-local:
 
 clean-local:
 	cargo clean
-
-tt:
-	echo BOB ${DEBUG} END

--- a/Makefile.am
+++ b/Makefile.am
@@ -106,6 +106,7 @@ COMPLETIONS_OUT_DIR = target/release/completions
 
 casile$(EXEEXT): $(CARGO_TARGET)
 	cp -bf $< $@
+	ln -sf ../$@ bin/$@
 
 $(COMPLETIONS_OUT_DIR)/$(_casile): $(CARGO_TARGET)
 	cp -bf $(COMPLETIONS_OUT_DIR)/casile.bash $@

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,8 +13,11 @@ EXTRA_DIST = package.json yarn.lock Dockerfile build-aux/docker-entrypoint.sh
 
 bin_PROGRAMS = casile
 
-casile_SOURCES = Cargo.toml build.rs src/main.rs src/lib.rs src/i18n.rs src/make.rs src/setup.rs src/shell.rs
-EXTRA_casile_SOURCES = Cargo.lock assets/en-US/cli.ftl assets/tr-TR/cli.ftl
+_casile_libs = src/lib.rs src/i18n.rs
+_casile_modules = src/make/mod.rs src/setup/mod.rs src/shell/mod.rs
+_casile_assets = assets/en-US/cli.ftl assets/tr-TR/cli.ftl
+casile_SOURCES = Cargo.toml build.rs src/main.rs $(_casile_libs) $(_casile_modules) $(_casile_assets)
+EXTRA_casile_SOURCES = Cargo.lock tests/cli.rs
 
 # use :read !git ls-files <pattern> to repopulate <pattern>_DATA vars
 
@@ -166,7 +169,7 @@ docker: Dockerfile build-aux/docker-entrypoint.sh
 		--tag siletypesetter/casile:HEAD \
 		./
 
-check-local:
+check-local: $(casile_SOURCES) $(EXTRA_casile_SOURCES)
 	cargo test --locked
 
 clean-local:

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@ datadir = $(datarootdir)/$(_casile)
 dist_doc_DATA = README.md CHANGELOG.md
 dist_license_DATA = LICENSE.txt
 
-EXTRA_DIST = package.json yarn.lock Dockerfile build-aux/docker-entrypoint.sh
+EXTRA_DIST = package.json yarn.lock Dockerfile
 
 bin_PROGRAMS = casile
 
@@ -163,7 +163,7 @@ tagrelease:
 release: tagrelease
 
 .PHONY: docker
-docker: Dockerfile build-aux/docker-entrypoint.sh
+docker: Dockerfile
 	docker build \
 		--build-arg VCS_REF="$(VERSION)" \
 		--tag siletypesetter/casile:HEAD \

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ There are several different ways to use CaSILE, with or without installation.
 
 * Using Docker.
 
-  - Pros: No dependencies to run and hence very easy to get started, easy to switch between versions including full dependency stack.
-  - Cons: Tricky to setup access to fonts or other resources available outside your project.
+  - Pros: No dependencies to run and hence very easy to get started, easy to switch between versions including full matching dependency stack.
+  - Cons: Tricky to setup access to fonts or other resources available outside your project. Some overhead in startup time and reduced CPU and memory resources.
 
 * From a CI runner.
 
@@ -112,10 +112,20 @@ It is also possible to mix and match, notably you can use both local options and
 
 1. Clone the Git repository or download and extract a source tarball.
 
+2. Optionally create a symlink to the external directory so the location can be changed without editing your makefile:
+
+    ```bash
+    $ ln -s /path/to/casile
+    ```
+
 2. Include the rules file from your project's Makefile:
 
     ```makefile
-    include path/to/casile/rules
+    # Direct approach
+    include /path/to/casile/rules
+
+    # Optional symlinked approach
+    include casile/rules
     ```
 
 3. Initialize the toolkit before first use:
@@ -149,7 +159,12 @@ If you are using Arch Linux, take your pick of AUR recipes at [casile][aur-casil
        $ make install
        ```
 
-  b. "Install" to your user by adding the base CasILE directory to your `$PATH`.
+  b. "Install" for just your user by adding the CasILE bin directory to your `$PATH`.
+
+      ```bash
+      # Can be added to your .bashrc or similar...
+      export PATH="~/path/to/casile/bin:$PATH"
+      ```
 
 4. Include the rules file from your project's Makefile:
 
@@ -173,15 +188,19 @@ Optionally you may build a docker image yourself. From any CasILE source directo
 
 Once installed, the docker image run command can be substituted anywhere you would invoke CaSILE. For convenience you'll probably want to give yourself an alias:
 
-    alias casile-docker='docker run --volume "$(pwd):/data" --user "$(id -u):$(id -g)" siletypesetter/casile:latest
+```bash
+alias casile-docker='docker run -it --volume "$(pwd):/data" --user "$(id -u):$(id -g)" siletypesetter/casile:latest'
+```
 
-Now instead of running `make my_book-a4-print.pdf` you would run `casile-docker make my_book-a4-print.pdf`. This substitution should work anywhere *make* would be run.
+Now instead of running `make my_book-a4-print.pdf` you would run `casile-docker make my_book-a4-print.pdf`. This substitution should work anywhere you would have run `make` in a submodule or linked directory usage.
 
 ### CI Setup
 
 (To be documented.)
 
-    $ make .gitlab-conf.yml
+```bash
+$ make .gitlab-conf.yml
+```
 
 ## Input
 

--- a/build-aux/docker-entrypoint.sh
+++ b/build-aux/docker-entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-set -e
-
-if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ]; then
-  set -- casile "$@"
-fi
-
-exec "$@"

--- a/build.rs
+++ b/build.rs
@@ -19,8 +19,7 @@ fn main() {
     // let outdir = env::var_os("OUT_DIR").unwrap();
     let profile = env::var("PROFILE").unwrap();
     let completionsdir = format!("target/{}/completions", profile);
-    fs::create_dir(&completionsdir).unwrap();
-    println!("CoDi {}", &completionsdir);
+    fs::create_dir_all(&completionsdir).unwrap();
     let mut app = Cli::into_app();
     let bin_name = "casile";
     generate_to::<Bash, _, _>(&mut app, bin_name, &completionsdir);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,7 +31,7 @@ pub enum Subcommand {
         target: Vec<String>,
     },
 
-    /// Configure a book repository
+    /// Configure a project repository
     Setup {
         /// Path to project repository
         #[clap(default_value = "./")]
@@ -40,7 +40,10 @@ pub enum Subcommand {
 
     /// Pass any command through to the system shell
     Shell {
-        #[clap(default_value = "bash")]
+        /// Enter interactive shell
+        #[clap(short, long)]
+        interactive: bool,
+
         command: Vec<String>,
     },
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -76,7 +76,7 @@ fn normalize_lang(input: &String) -> String {
 }
 
 // https://github.com/projectfluent/fluent-rs/blob/c9e45651/fluent-resmgr/examples/simple-resmgr.rs#L35
-fn list_available_locales() -> Vec<LanguageIdentifier> {
+fn list_available_locales() -> Locales {
     let mut embeded = vec![];
     for asset in Asset::iter() {
         let asset_name = asset.to_string();
@@ -97,7 +97,7 @@ fn list_available_locales() -> Vec<LanguageIdentifier> {
         }
     }
     embeded.dedup();
-    embeded
+    Locales(embeded)
 }
 
 fn translate(key: &str, args: Option<&FluentArgs>) -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,9 @@ fn main() -> Result<(), Box<dyn error::Error>> {
     match args.subcommand {
         Subcommand::Make { target } => make::run(target),
         Subcommand::Setup { path } => setup::run(path),
-        Subcommand::Shell { command } => shell::run(command),
+        Subcommand::Shell {
+            command,
+            interactive,
+        } => shell::run(command, interactive),
     }
 }

--- a/src/make/mod.rs
+++ b/src/make/mod.rs
@@ -1,9 +1,11 @@
 use crate::CONFIG;
-use std::error;
+use std::{error, result};
 use subprocess::Exec;
 
+type Result<T> = result::Result<T, Box<dyn error::Error>>;
+
 /// Execute GNU Make on given target
-pub fn run(target: Vec<String>) -> Result<(), Box<dyn error::Error>> {
+pub fn run(target: Vec<String>) -> Result<()> {
     crate::header("make-header");
     let mut process = Exec::cmd("make").args(&target);
     if CONFIG.get_bool("debug")? {

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1,3 +1,4 @@
+use crate::i18n::LocalText;
 use git2::Repository;
 use std::{error, fs, io, path, result};
 
@@ -10,14 +11,20 @@ pub fn run(path: path::PathBuf) -> Result<()> {
     match metadata.is_dir() {
         true => match Repository::open(path) {
             Ok(_repo) => Ok(()),
-            Err(_error) => Err(Box::new(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "", // config.locale.translate("setup-error-not-git", None),
-            ))),
+            Err(_error) => {
+                let error_text = LocalText::new("setup-error-not-git");
+                Err(Box::new(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    error_text.fmt(None),
+                )))
+            }
         },
-        false => Err(Box::new(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            "", // config.locale.translate("setup-error-not-dir", None),
-        ))),
+        false => {
+            let error_text = LocalText::new("setup-error-not-dir");
+            Err(Box::new(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                error_text.fmt(None),
+            )))
+        }
     }
 }

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1,8 +1,10 @@
 use git2::Repository;
-use std::{error, fs, io, path};
+use std::{error, fs, io, path, result};
+
+type Result<T> = result::Result<T, Box<dyn error::Error>>;
 
 /// Setup CaSILE config file(s) on new repository
-pub fn run(path: path::PathBuf) -> Result<(), Box<dyn error::Error>> {
+pub fn run(path: path::PathBuf) -> Result<()> {
     crate::header("setup-header");
     let metadata = fs::metadata(&path)?;
     match metadata.is_dir() {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -5,20 +5,21 @@ use subprocess::Exec;
 
 type Result<T> = result::Result<T, Box<dyn error::Error>>;
 
+/// Exectute some set of argumets as a shell command with CaSILE related enviroment variables set.
 pub fn run(command: Vec<String>, interactive: bool) -> Result<()> {
     crate::header("shell-header");
-    let locales = LOCALES.read().unwrap();
+    let locales = LOCALES.read()?;
     let locale = locales[0].to_string();
     let lang: &str = &[&locale.replace("-", "_"), "utf8"].join(".");
     let mut process = Exec::cmd("zsh").env("LANG", lang);
     if CONFIG.get_bool("debug")? {
         process = process.env("CASILE_DEBUG", "true").arg("-x");
     };
-    if interactive {
-        process = process.arg("-i")
+    let process = if interactive {
+        process.arg("-i")
     } else {
-        process = process.arg("-c").arg(command.join(" "));
-    }
+        process.arg("-c").arg(command.join(" "))
+    };
     process.join()?;
     Ok(())
 }


### PR DESCRIPTION
First, this lets the CLI take charge in Docker. The CLI is the entry point now. At this point it can basically invoke `make` and/or pass through other shell commands. It can also launch an interactive shell with some environment things normalized. You can still get a regular bash shell in the Docker image by manually using `docker run --entrypoint=bash` or whatever.

Additionally this refactors a bunch of how the rust module scope is put together and introduces much more idiomatic way of accessing translated strings.