### PR TITLE
fix: Fix order so we can't possibly measure an empty stack

### DIFF
--- a/casile.lua
+++ b/casile.lua
@@ -669,15 +669,15 @@ SILE.registerCommand("dropcap", function (_, content)
 end)
 
 SILE.registerCommand("requireSpace", function (options, content)
-	local required = SILE.length(options.height or 1)
-	SILE.typesetter:leaveHmode()
-	SILE.Commands["hbox"]({}, content)
-	table.remove(SILE.typesetter.state.nodes) -- steal it back
-	local heightOfPageSoFar = SILE.pagebuilder.collateVboxes(SILE.typesetter.state.outputQueue).height
-	local heightOfFrame = SILE.typesetter.frame:height()
-	if heightOfFrame - heightOfPageSoFar < required then
-		SILE.call("supereject")
-	end
+  local required = SILE.length(options.height or 0)
+  SILE.typesetter:leaveHmode()
+  SILE.call("hbox", {}, content) -- push content we want to fit
+  local heightOfPageSoFar = SILE.pagebuilder:collateVboxes(SILE.typesetter.state.outputQueue).height
+  local heightOfFrame = SILE.typesetter.frame:height()
+  table.remove(SILE.typesetter.state.nodes) -- steal it back
+  if heightOfFrame - heightOfPageSoFar < required then
+    SILE.call("supereject")
+  end
 end)
 
 SILE.registerUnit("%pmed", { relative = true, definition = function (v)


### PR DESCRIPTION
Stealing the `hbox` back before measuring was leaving open the chance for a completely empty queue, in which case it wouldn't be able to figure a height at all. Running this at the top of a page is unlikely but possible — as evidenced by my CI job for a book that started to fail!