### PR TITLE
Bring use in GitLab CI to parity with GitHub Actions

### DIFF
--- a/assets/en-US/cli.ftl
+++ b/assets/en-US/cli.ftl
@@ -141,3 +141,6 @@ status-header =
 
 status-is-gha =
   Are we running as a GitHub Action?
+
+status-is-glc =
+  Are we running as a GitLab CI job?

--- a/assets/en-US/cli.ftl
+++ b/assets/en-US/cli.ftl
@@ -115,6 +115,9 @@ setup-bad =
 setup-is-repo =
   Is the path a Git repository?
 
+setup-is-not-casile =
+  Are we not in the CaSILE source repository?
+
 setup-is-writable =
   Can we write to the project base directory?
 

--- a/assets/tr-TR/cli.ftl
+++ b/assets/tr-TR/cli.ftl
@@ -46,3 +46,6 @@ status-header =
 
 status-is-gha =
   GitHub Action olarak mı çalıştırıldık?
+
+status-is-glc =
+  GitLab CI iş olarak mı çalıştırıldık?

--- a/assets/tr-TR/cli.ftl
+++ b/assets/tr-TR/cli.ftl
@@ -29,6 +29,9 @@ setup-bad =
 setup-is-repo =
   Dizin yolu bir Git deposu mudur?
 
+setup-is-not-casile =
+  CaSILE kaynak deposu üzerinden başka yerde miyiz?
+
 setup-is-writable =
   Projenin kök klasöründe yazma izinimiz var mıdır?
 

--- a/rules/utilities.mk
+++ b/rules/utilities.mk
@@ -1,3 +1,5 @@
+NONDISTGOALS = $(filter-out %dist $(DISTDIR).% _glc.env,$(MAKECMDGOALS))
+
 .PHONY: clean
 clean:
 	rm -rf $(BUILDDIR) $(DISTDIR) $(call extantfiles,$(DISTFILES))
@@ -6,7 +8,6 @@ clean:
 .PHONY: dist
 dist: $(DISTDIR).zip $(DISTDIR).tar.gz
 
-NONDISTGOALS = $(filter-out %dist $(DISTDIR).%,$(MAKECMDGOALS))
 .PHONY: install-dist
 install-dist: $(NONDISTGOALS) | $(DISTDIR)
 install-dist: $$(or $$(call extantfiles,$$(DISTFILES)),fail)
@@ -87,6 +88,14 @@ _gha:
 	echo "::set-output name=DISTDIR::$(DISTDIR)"
 	echo "::set-output name=PROJECT::$(PROJECT)"
 	echo "::set-output name=VERSION::$(call versioninfo,$(PROJECT))"
+
+_glc.env: $(NONDISTGOALS)
+	$(ZSH) << 'EOF' # inception to break out of CaSILE’s make shell wrapper
+	export PS4=; set -x ; exec 2> $@ # black magic to output sourcable content
+	DISTDIR="$(DISTDIR)"
+	PROJECT="$(PROJECT)"
+	VERSION="$(call versioninfo,$(PROJECT))"
+	EOF
 
 .PHONY: list
 list:

--- a/rules/utilities.mk
+++ b/rules/utilities.mk
@@ -1,4 +1,4 @@
-NONDISTGOALS = $(filter-out %dist $(DISTDIR).% _glc %.env,$(MAKECMDGOALS))
+NONDISTGOALS = $(filter-out %dist $(DISTDIR).% _gha _glc %.env,$(MAKECMDGOALS))
 
 .PHONY: clean
 clean:

--- a/rules/utilities.mk
+++ b/rules/utilities.mk
@@ -1,4 +1,4 @@
-NONDISTGOALS = $(filter-out %dist $(DISTDIR).% _glc.env,$(MAKECMDGOALS))
+NONDISTGOALS = $(filter-out %dist $(DISTDIR).% _glc %.env,$(MAKECMDGOALS))
 
 .PHONY: clean
 clean:
@@ -89,7 +89,11 @@ _gha:
 	echo "::set-output name=PROJECT::$(PROJECT)"
 	echo "::set-output name=VERSION::$(call versioninfo,$(PROJECT))"
 
-_glc.env: $(NONDISTGOALS)
+
+.PHONY: _glc
+_glc: $(CI_JOB_NAME).env
+
+$(CI_JOB_NAME).env: $(NONDISTGOALS)
 	$(ZSH) << 'EOF' # inception to break out of CaSILE’s make shell wrapper
 	export PS4=; set -x ; exec 2> $@ # black magic to output sourcable content
 	DISTDIR="$(DISTDIR)"

--- a/src/make/mod.rs
+++ b/src/make/mod.rs
@@ -41,7 +41,7 @@ pub fn run(target: Vec<String>) -> Result<()> {
         targets.push(String::from("install-dist"));
     }
     if status::is_glc()? {
-        targets.push(String::from("_glc.env"));
+        targets.push(String::from("_glc"));
         if targets.len() == 1 {
             targets.push(String::from("default"));
         }

--- a/src/make/mod.rs
+++ b/src/make/mod.rs
@@ -41,7 +41,8 @@ pub fn run(target: Vec<String>) -> Result<()> {
         targets.push(String::from("install-dist"));
     }
     if status::is_glc()? {
-        if targets.len() == 0 {
+        targets.push(String::from("_glc.env"));
+        if targets.len() == 1 {
             targets.push(String::from("default"));
         }
         targets.push(String::from("install-dist"));

--- a/src/make/mod.rs
+++ b/src/make/mod.rs
@@ -40,6 +40,12 @@ pub fn run(target: Vec<String>) -> Result<()> {
         }
         targets.push(String::from("install-dist"));
     }
+    if status::is_glc()? {
+        if targets.len() == 0 {
+            targets.push(String::from("default"));
+        }
+        targets.push(String::from("install-dist"));
+    }
     let mut process = Exec::cmd("make")
         .args(&makeflags)
         .args(&makefiles)

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -53,6 +53,10 @@ pub fn is_setup() -> Result<bool> {
     if results.read().unwrap().iter().all(|&v| v) {
         rayon::scope(|s| {
             s.spawn(|_| {
+                let ret = is_not_casile_source().unwrap();
+                results.write().unwrap().push(ret);
+            });
+            s.spawn(|_| {
                 let ret = is_writable().unwrap();
                 results.write().unwrap().push(ret);
             });
@@ -77,6 +81,16 @@ pub fn is_setup() -> Result<bool> {
 pub fn is_repo() -> Result<bool> {
     let ret = get_repo().is_ok();
     display_check("setup-is-repo", ret);
+    Ok(ret)
+}
+
+/// Are we not in the CaSILE source repo?
+pub fn is_not_casile_source() -> Result<bool> {
+    let repo = get_repo()?;
+    let workdir = repo.workdir().unwrap();
+    let testfile = workdir.join("make-shell.zsh.in");
+    let ret = fs::File::open(&testfile).is_err();
+    display_check("setup-is-not-casile", ret);
     Ok(ret)
 }
 

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -90,7 +90,7 @@ pub fn is_writable() -> Result<bool> {
     fs::remove_file(&testfile)?;
     let ret = true;
     display_check("setup-is-writable", ret);
-    Ok(true)
+    Ok(ret)
 }
 
 /// Check if we can execute the system's `make` utility
@@ -102,7 +102,7 @@ pub fn is_make_exectuable() -> Result<bool> {
         .join()
         .is_ok();
     display_check("setup-is-make-executable", ret);
-    Ok(true)
+    Ok(ret)
 }
 
 /// Check that the system's `make` utility is GNU Make
@@ -115,7 +115,7 @@ pub fn is_make_gnu() -> Result<bool> {
         .stdout_str();
     let ret = out.starts_with("GNU Make 4.");
     display_check("setup-is-make-gnu", ret);
-    Ok(true)
+    Ok(ret)
 }
 
 fn regen_gitignore(repo: Repository) -> Result<()> {

--- a/src/status/mod.rs
+++ b/src/status/mod.rs
@@ -35,6 +35,13 @@ pub fn is_gha() -> Result<bool> {
     Ok(ret)
 }
 
+/// Check to see if we're running in GitLab CI
+pub fn is_glc() -> Result<bool> {
+    let ret = env::var("GITLAB_CI").is_ok();
+    display_check("status-is-glc", ret);
+    Ok(ret)
+}
+
 /// Figure out if we're running inside Docker or another container
 pub fn is_container() -> bool {
     let dockerenv = path::Path::new("/.dockerenv");


### PR DESCRIPTION
- fix(cli): Return correct state for status checks
- feat(cli): Abort if being run on CaSILE sourec repo
- feat(gitlab): Add runtime detection of GitLab CI
- feat(gitlab): Output dist artifacts by default if run in CI job
- feat(gitlab): Export dotenv vars for GHA feature parity
- feat(gitlab): Pass dotenv variables on a per-job basis
- chore(actions): Don't bother with GHA meta taget
