### PR TITLE
Fix hickups building non-default branches in CI

### DIFF
--- a/rules/rules.mk
+++ b/rules/rules.mk
@@ -194,7 +194,7 @@ SILEFLAGS += -d $(subst $( ),$(,),$(strip $(DEBUGTAGS)))
 endif
 
 # Most CI runners need help getting the branch name because of sparse checkouts
-BRANCH := $(or $(CI_COMMIT_REF_NAME),$(shell $(_ENV) $(GIT) rev-parse --abbrev-ref HEAD))
+BRANCH := $(or $(CI_COMMIT_REF_NAME),$(GITHUB_HEAD_REF),$(GITHUB_REF),$(shell $(_ENV) $(GIT) rev-parse --abbrev-ref HEAD))
 TAG := $(or $(CI_COMMIT_TAG),$(shell $(_ENV) $(GIT) describe --tags --exact-match 2>/dev/null))
 ALLTAGS := $(strip $(CI_COMMIT_TAG) $(shell $(_ENV) $(GIT) tag --points-at HEAD | $(XARGS) echo))
 

--- a/rules/rules.mk
+++ b/rules/rules.mk
@@ -197,6 +197,7 @@ endif
 BRANCH := $(or $(CI_COMMIT_REF_NAME),$(GITHUB_HEAD_REF),$(GITHUB_REF),$(shell $(_ENV) $(GIT) rev-parse --abbrev-ref HEAD))
 TAG := $(or $(CI_COMMIT_TAG),$(shell $(_ENV) $(GIT) describe --tags --exact-match 2>/dev/null))
 ALLTAGS := $(strip $(CI_COMMIT_TAG) $(shell $(_ENV) $(GIT) tag --points-at HEAD | $(XARGS) echo))
+PARENT ?= $(shell $(_ENV) $(GIT) merge-base $(or $(CI_MERGE_REQUEST_SOURCE_BRANCH_NAME),$(GITHUB_BASE_REF),master) $(BRANCH))
 
 # Add mock-ups to sources
 ifeq ($(strip $(MOCKUPS)),true)

--- a/rules/utilities.mk
+++ b/rules/utilities.mk
@@ -91,7 +91,6 @@ _gha:
 	echo "::set-output name=PROJECT::$(PROJECT)"
 	echo "::set-output name=VERSION::$(call versioninfo,$(PROJECT))"
 
-
 .PHONY: _glc
 _glc: $(CI_JOB_NAME).env
 


### PR DESCRIPTION
- chore(actions): Integrate GitHub variables alongside GitLab ones
- fix(rules): Reinstate parent branch discovery, overzealously removed in 113d51f
