### PR TITLE
fix(rules): Correct Pandoc template override variable

### DIFF
--- a/rules/rules.mk
+++ b/rules/rules.mk
@@ -379,7 +379,7 @@ ifeq ($(LANGUAGE),tr)
 ah := $(PERL) $(PERLARGS) -pne '/^\#/ or s/(?<=\p{L})’(?=\p{L})/\\ah{}/g' |
 endif
 
-PANDOCTEMPLATE ?= $(CASILEDIR)/travis.yml
+PANDOCTEMPLATE ?= $(CASILEDIR)/template.sil
 
 FULLSILS := $(addprefix $(BUILDDIR)/,$(call pattern_list,$(SOURCES),$(REALLAYOUTS),.sil))
 FULLSILS += $(addprefix $(BUILDDIR)/,$(call pattern_list,$(SOURCES),$(EDITS),$(REALLAYOUTS),.sil))


### PR DESCRIPTION
This is an egregious little bug, it would never work for anybody that wasn't using a toolkit or project that happened to use custom Pandoc templates. That happens to have been every project I've done since the 0.7.0 release.