### PR TITLE
Slightly more aggresively refactor with SILE v0.14 tooling

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -29,13 +29,11 @@ files["pandoc-filters"] = {
   ignore = { "4.2" }
 }
 globals = {
-  "CASILE",
   "SILE",
   "SU",
-  "std",
+  "luautf8",
   "pl",
-  "SYSTEM_SILE_PATH",
-  "SHARED_LIB_EXT",
-  "ProFi"
+  "fluent",
+  "CASILE"
 }
 max_line_length = false

--- a/Makefile.am
+++ b/Makefile.am
@@ -78,10 +78,11 @@ filtersdir = $(datadir)/pandoc-filters
 dist_filters_DATA = pandoc-filters/chapterid.lua pandoc-filters/epubclean.lua pandoc-filters/strip_for_mdbook.lua pandoc-filters/svg2pdf.py pandoc-filters/withoutfootnotes.lua pandoc-filters/withoutheadinglinks.lua pandoc-filters/withoutlinks.lua pandoc-filters/withverses.lua
 
 classesdir = $(datadir)/classes
-dist_classes_DATA = classes/cabook.lua classes/cabinding.lua classes/commands.lua classes/inline-styles.lua classes/block-styles.lua
+dist_classes_DATA = classes/cabook.lua classes/cabinding.lua
 
 packagesdir = $(datadir)/packages
 dist_packages_DATA = packages/covers.lua packages/crop.lua packages/imprint.lua packages/lists.lua packages/markdown.lua packages/verseindex.lua
+dist_packages_DATA += packages/cabook-commands.lua packages/cabook-inline-styles.lua packages/cabook-block-styles.lua
 
 layoutsdir = $(datadir)/layouts
 dist_layouts_DATA = layouts/a4.lua layouts/a4ciltli.lua layouts/a5trim.lua layouts/a6.lua layouts/a6trim.lua layouts/a7.lua layouts/a7kart.lua layouts/a7trimkart.lua layouts/app.lua layouts/banner.lua layouts/businesscard.lua layouts/cep.lua layouts/ekran.lua layouts/epub.lua layouts/halfletter.lua layouts/octavo.lua layouts/royaloctavo.lua layouts/square.lua layouts/wide.lua

--- a/classes/cabook.lua
+++ b/classes/cabook.lua
@@ -127,7 +127,7 @@ end
 
 function cabook:endPage ()
   self:moveTocNodes()
-  if self.moveTovNodes then self:moveTovNodes() end
+  if self.packages.verseindex then self.packages.verseindex:moveTovNodes() end
   if not SILE.scratch.headers.skipthispage then
     SILE.settings:pushState()
     SILE.settings:reset()
@@ -140,13 +140,13 @@ function cabook:endPage ()
   end
   SILE.scratch.headers.skipthispage = false
   local ret = plain.endPage(self)
-  if self.options.crop then self:outputCropMarks() end
+  if self.options.crop then self.packages.crop:outputCropMarks() end
   return ret
 end
 
 function cabook:finish ()
-  if self.moveTovNodes then
-    self:writeTov()
+  if self.packages.verseindex then
+    self.packages.verseindex:writeTov()
     SILE.call("tableofverses")
   end
   return book.finish(self)

--- a/classes/cabook.lua
+++ b/classes/cabook.lua
@@ -23,6 +23,9 @@ function cabook:_init (options)
   end
   self:loadPackage("imprint")
   self:loadPackage("covers")
+  self:loadPackage("cabook-commands")
+  self:loadPackage("cabook-inline-styles")
+  self:loadPackage("cabook-block-styles")
   self:registerPostinit(function (_)
     -- CaSILE books sometimes have sections, sometimes don't.
     -- Initialize some sectioning levels to work either way
@@ -98,10 +101,6 @@ end
 
 function cabook:registerCommands ()
   book.registerCommands(self)
-  -- SILE's loadPackage assumes a "packages" path, this just side steps that naming requirement
-  self:initPackage(require("classes.commands"))
-  self:initPackage(require("classes.inline-styles"))
-  self:initPackage(require("classes.block-styles"))
 end
 
 function cabook:endPage ()

--- a/classes/cabook.lua
+++ b/classes/cabook.lua
@@ -127,7 +127,6 @@ end
 
 function cabook:endPage ()
   self:moveTocNodes()
-  if self.packages.verseindex then self.packages.verseindex:moveTovNodes() end
   if not SILE.scratch.headers.skipthispage then
     SILE.settings:pushState()
     SILE.settings:reset()
@@ -140,16 +139,7 @@ function cabook:endPage ()
   end
   SILE.scratch.headers.skipthispage = false
   local ret = plain.endPage(self)
-  if self.options.crop then self.packages.crop:outputCropMarks() end
   return ret
-end
-
-function cabook:finish ()
-  if self.packages.verseindex then
-    self.packages.verseindex:writeTov()
-    SILE.call("tableofverses")
-  end
-  return book.finish(self)
 end
 
 return cabook

--- a/classes/cabook.lua
+++ b/classes/cabook.lua
@@ -6,7 +6,6 @@ cabook._name = "cabook"
 
 function cabook:_init (options)
   book._init(self, options)
-
   self:loadPackage("color")
   self:loadPackage("ifattop")
   self:loadPackage("leaders")
@@ -19,28 +18,21 @@ function cabook:_init (options)
   self:loadPackage("frametricks")
   self:loadPackage("inputfilter")
   self:loadPackage("linespacing")
-
   if self.options.verseindex then
     self:loadPackage("verseindex")
   end
-
   self:loadPackage("imprint")
   self:loadPackage("covers")
-
   self:registerPostinit(function (_)
-
     -- CaSILE books sometimes have sections, sometimes don't.
     -- Initialize some sectioning levels to work either way
     SILE.scratch.counters["sectioning"] = {
       value =  { 0, 0 },
       display = { "ORDINAL", "STRING" }
     }
-
     require("hyphenation_exceptions")
-
     SILE.settings:set("typesetter.underfulltolerance", SILE.length("6ex"))
     SILE.settings:set("typesetter.overfulltolerance", SILE.length("0.2ex"))
-
     table.insert(SILE.input.preambles, function ()
       SILE.call("footnote:separator", {}, function ()
         SILE.call("rebox", { width = "6em", height = "2ex" }, function ()
@@ -48,18 +40,13 @@ function cabook:_init (options)
         end)
         SILE.call("medskip")
       end)
-
       SILE.call("cabook:font:serif", { size = "11.5pt" })
     end)
-
     SILE.settings:set("linespacing.method", "fit-font")
     SILE.settings:set("linespacing.fit-font.extra-space", SILE.length("0.6ex plus 0.2ex minus 0.2ex"))
     SILE.settings:set("linebreak.hyphenPenalty", 300)
-
     SILE.scratch.insertions.classes.footnote.interInsertionSkip = SILE.length("0.7ex plus 0 minus 0")
-
     SILE.scratch.last_was_ref = false
-
     SILE.typesetter:registerPageEndHook(function ()
       SILE.scratch.last_was_ref = false
     end)
@@ -67,11 +54,7 @@ function cabook:_init (options)
 end
 
 function cabook:declareSettings ()
-
   book.declareSettings(self)
-
-  -- require("classes.cabook-settings")()
-
 end
 
 function cabook:declareOptions ()
@@ -93,7 +76,6 @@ function cabook:declareOptions ()
       if value then verseindex = SU.cast("boolean", value) end
       return verseindex
     end)
-    -- SU.error("ga cl 2.5")
   self:declareOption("layout", function (_, value)
     if value then
       layout = value
@@ -115,18 +97,14 @@ function cabook:setOptions (options)
 end
 
 function cabook:registerCommands ()
-
   book.registerCommands(self)
-
   -- SILE's loadPackage assumes a "packages" path, this just side steps that naming requirement
   self:initPackage(require("classes.commands"))
   self:initPackage(require("classes.inline-styles"))
   self:initPackage(require("classes.block-styles"))
-
 end
 
 function cabook:endPage ()
-  self:moveTocNodes()
   if not SILE.scratch.headers.skipthispage then
     SILE.settings:pushState()
     SILE.settings:reset()
@@ -138,8 +116,7 @@ function cabook:endPage ()
     SILE.settings:popState()
   end
   SILE.scratch.headers.skipthispage = false
-  local ret = plain.endPage(self)
-  return ret
+  return plain.endPage(self)
 end
 
 return cabook

--- a/packages/cabook-block-styles.lua
+++ b/packages/cabook-block-styles.lua
@@ -1,15 +1,20 @@
+local base = require("packages.base")
+
+local package = pl.class(base)
+package._name = "cabook-block-styles"
+
 -- luacheck: ignore loadstring
 local loadstring = loadstring or load
 
-local function registerCommands (_)
+function package:registerCommands ()
 
-  SILE.registerCommand("foliostyle", function (_, content)
+  self:registerCommand("foliostyle", function (_, content)
     SILE.call("center", {}, function ()
       SILE.call("cabook:font:folio", {}, content)
     end)
   end)
 
-  SILE.registerCommand("titlepage", function (_, _)
+  self:registerCommand("titlepage", function (_, _)
     if not SILE.Commands["meta:title"] then return end
     SILE.call("nofolios")
     if not CASILE.isScreenLayout() then
@@ -45,7 +50,7 @@ local function registerCommands (_)
     SILE.call("break")
   end)
 
-  SILE.registerCommand("halftitlepage", function (_, _)
+  self:registerCommand("halftitlepage", function (_, _)
     if CASILE.isScreenLayout() then return end
     if not SILE.Commands["meta:title"] then return end
     SILE.call("nofolios")
@@ -60,7 +65,7 @@ local function registerCommands (_)
     end)
   end)
 
-  SILE.registerCommand("tableofcontents", function (_, _)
+  self:registerCommand("tableofcontents", function (_, _)
     local f, _ = io.open(SILE.masterFilename .. '.toc')
     if not f then return end
     local doc = f:read("*all")
@@ -78,7 +83,7 @@ local function registerCommands (_)
     SILE.call("tableofcontents:footer")
   end)
 
-  SILE.registerCommand("cabook:chapter:before", function (options, _)
+  self:registerCommand("cabook:chapter:before", function (options, _)
     SILE.call("open-double-page")
     SILE.call("noindent")
     -- If Sectioning doesn't output numbering, the chapter starts too high on the page
@@ -89,7 +94,7 @@ local function registerCommands (_)
     SILE.call("skip", { height = "10%ph" })
   end)
 
-  SILE.registerCommand("cabook:chapter:after", function (options, _)
+  self:registerCommand("cabook:chapter:after", function (options, _)
     SILE.call("bigskip")
     SILE.call("noindent")
     SILE.call("fullrule")
@@ -100,7 +105,7 @@ local function registerCommands (_)
     --SILE.call("nofoliosthispage")
   end)
 
-  SILE.registerCommand("chapter", function (options, content)
+  self:registerCommand("chapter", function (options, content)
     options.display = options.display or "STRING"
     options.numbering = SU.boolean(options.numbering, true)
     SILE.call("set-counter", { id = "footnote", value = 1 })
@@ -126,7 +131,7 @@ local function registerCommands (_)
     SILE.call("cabook:chapter:after", options, content)
   end, "Begin a new chapter");
 
-  SILE.registerCommand("section", function (_, content)
+  self:registerCommand("section", function (_, content)
     SILE.call("goodbreak")
     SILE.call("ifnotattop", {}, function ()
       SILE.call("skip", { height = "12pt plus 6pt minus 4pt" })
@@ -142,7 +147,7 @@ local function registerCommands (_)
     SILE.call("novbreak")
   end, "Begin a new section")
 
-  SILE.registerCommand("subsection", function (_, content)
+  self:registerCommand("subsection", function (_, content)
     SILE.call("goodbreak")
     SILE.call("ifnotattop", {}, function ()
       SILE.call("skip", { height = "12pt plus 6pt minus 4pt" })
@@ -158,7 +163,7 @@ local function registerCommands (_)
     SILE.call("novbreak")
   end, "Begin a new section")
 
-  SILE.registerCommand("subsubsection", function (_, content)
+  self:registerCommand("subsubsection", function (_, content)
     SILE.call("goodbreak")
     SILE.call("ifnotattop", {}, function ()
       SILE.call("skip", { height = "12pt plus 6pt minus 4pt" })
@@ -174,7 +179,7 @@ local function registerCommands (_)
     SILE.call("novbreak")
   end, "Begin a new section")
 
-  SILE.registerCommand("part", function (options, content)
+  self:registerCommand("part", function (options, content)
     SILE.call("open-double-page")
     SILE.call("noindent")
     SILE.call("set-counter", { id = "footnote", value = 1})
@@ -201,7 +206,7 @@ local function registerCommands (_)
     SILE.scratch.headers.skipthispage = true
   end, "Begin a new part");
 
-  SILE.registerCommand("subparagraph", function (_, content)
+  self:registerCommand("subparagraph", function (_, content)
     SILE.typesetter:leaveHmode()
     SILE.call("novbreak")
     -- Backtracking to approximate the skip after quotations
@@ -222,6 +227,4 @@ local function registerCommands (_)
 
 end
 
-return {
-  registerCommands = registerCommands
-}
+return package

--- a/packages/cabook-inline-styles.lua
+++ b/packages/cabook-inline-styles.lua
@@ -1,121 +1,126 @@
-local function registerCommands (_)
+local base = require("packages.base")
+
+local package = pl.class(base)
+package._name = "cabook-inline-styles"
+
+function package:registerCommands ()
 
   -- General purpose font families (no sizes)
 
-  SILE.registerCommand("cabook:font:serif", function (options, content)
+  self:registerCommand("cabook:font:serif", function (options, content)
     options.family = options.family or "Libertinus Serif"
     SILE.call("font", options, content)
   end)
 
-  SILE.registerCommand("cabook:font:sans", function (options, content)
+  self:registerCommand("cabook:font:sans", function (options, content)
     options.family = options.family or "Libertinus Sans"
     SILE.call("font", options, content)
   end)
 
-  SILE.registerCommand("cabook:font:mono", function (options, content)
+  self:registerCommand("cabook:font:mono", function (options, content)
     options.family = options.family or "Hack"
     SILE.call("font", options, content)
   end)
 
-  SILE.registerCommand("cabook:font:display", function (options, content)
+  self:registerCommand("cabook:font:display", function (options, content)
     options.family = options.family or "Libertinus Serif Display"
     SILE.call("font", options, content)
   end)
 
-  SILE.registerCommand("cabook:font:alt", function (options, content)
+  self:registerCommand("cabook:font:alt", function (options, content)
     SILE.call("cabook:font:serif", options, content)
   end)
 
   -- Fonts for specific locations in layouts (including default sizes)
 
-  SILE.registerCommand("cabook:font:parttitle", function (options, content)
+  self:registerCommand("cabook:font:parttitle", function (options, content)
     options.size = options.size or "4%pw"
     options.weight = options.weight or 600
     SILE.call("cabook:font:sans", options, content)
   end)
 
-  SILE.registerCommand("cabook:font:partno", function (options, content)
+  self:registerCommand("cabook:font:partno", function (options, content)
     options.size = options.size or "5%pw"
     SILE.call("cabook:font:parttitle", options, content)
   end)
 
-  SILE.registerCommand("cabook:font:title", function (options, content)
+  self:registerCommand("cabook:font:title", function (options, content)
     options.size = options.size or "2em"
     SILE.call("cabook:font:partno", options, content)
   end)
 
-  SILE.registerCommand("cabook:font:subtitle", function (options, content)
+  self:registerCommand("cabook:font:subtitle", function (options, content)
     options.size = options.size or "1.5em"
     SILE.call("cabook:font:parttitle", options, content)
   end)
 
-  SILE.registerCommand("cabook:font:author", function (options, content)
+  self:registerCommand("cabook:font:author", function (options, content)
     options.size = options.size or "1.2em"
     SILE.call("cabook:font:parttitle", options, content)
   end)
 
-  SILE.registerCommand("cabook:font:folio", function (options, content)
+  self:registerCommand("cabook:font:folio", function (options, content)
     options.size = options.size or "1.1em"
     options.weight = options.weight or 400
     options.style = options.style or "Roman"
     SILE.call("cabook:font:alt", options, content)
   end)
 
-  SILE.registerCommand("cabook:font:left-header", function (options, content)
+  self:registerCommand("cabook:font:left-header", function (options, content)
     options.size = options.size or "1.05em"
     SILE.call("cabook:font:alt", options, content)
   end)
 
-  SILE.registerCommand("cabook:font:right-header", function (options, content)
+  self:registerCommand("cabook:font:right-header", function (options, content)
     options.size = options.size or "1.05em"
     options.style = options.style or "Italic"
     SILE.call("cabook:font:left-header", options, content)
   end)
 
-  SILE.registerCommand("tableofcontents:headerfont", function (options, content)
+  self:registerCommand("tableofcontents:headerfont", function (options, content)
     options.size = options.size or "1.4em"
     SILE.call("cabook:font:parttitle", options, content)
   end)
 
-  SILE.registerCommand("cabook:font:dedication", function (options, content)
+  self:registerCommand("cabook:font:dedication", function (options, content)
     options.size = options.size or "1.15em"
     options.style = options.style or "Italic"
     SILE.call("cabook:font:serif", options, content)
   end)
 
-  SILE.registerCommand("cabook:font:footnote", function (options, content)
+  self:registerCommand("cabook:font:footnote", function (options, content)
     options.size = options.size or "0.74em"
     SILE.call("cabook:font:alt", options, content)
   end)
 
-  SILE.registerCommand("cabook:font:chaptertitle", function (options, content)
+  self:registerCommand("cabook:font:chaptertitle", function (options, content)
     options.weight = options.weight or 600
     options.size = options.size or "1.4em"
     SILE.call("cabook:font:serif", options, content)
   end)
 
-  SILE.registerCommand("cabook:font:chapterno", function (options, content)
+  self:registerCommand("cabook:font:chapterno", function (options, content)
     options.family = options.family or "Libertinus Serif Display"
     options.size = options.size or "0.96em"
     SILE.call("font", options, content)
   end)
 
-  SILE.registerCommand("cabook:font:sectiontitle", function (options, content)
+  self:registerCommand("cabook:font:sectiontitle", function (options, content)
     options.size = options.size or "0.92em"
     SILE.call("cabook:font:chaptertitle", options, content)
   end)
 
-  SILE.registerCommand("cabook:font:subsectiontitle", function (options, content)
+  self:registerCommand("cabook:font:subsectiontitle", function (options, content)
     options.size = options.size or "0.84em"
     SILE.call("cabook:font:sectiontitle", options, content)
   end)
 
-  SILE.registerCommand("cabook:font:subsubsectiontitle", function (options, content)
+  self:registerCommand("cabook:font:subsubsectiontitle", function (options, content)
     options.size = options.size or "0.76em"
     SILE.call("cabook:font:sectiontitle", options, content)
   end)
 
-  SILE.registerCommand("cabook:font:subparagraph", function (options, content)
+  self:registerCommand("cabook:font:subparagraph", function (options, content)
     options.size = options.size or "0.96em"
     options.features = options.features or "+smcp"
     SILE.call("cabook:font:alt", options, content)
@@ -123,26 +128,24 @@ local function registerCommands (_)
 
   -- Overrides for SILE style commands
 
-  SILE.registerCommand("code", function (options, content)
+  self:registerCommand("code", function (options, content)
     SILE.call("cabook:font:mono", options, content)
   end)
 
-  SILE.registerCommand("em", function (_, content)
+  self:registerCommand("em", function (_, content)
     SILE.call("font", { style = "Italic" }, content)
     SILE.call("kern", { width = "1pt" })
   end)
 
-  SILE.registerCommand("strong", function (_, content)
+  self:registerCommand("strong", function (_, content)
     SILE.call("font", { weight = 600 }, content)
   end)
 
-  SILE.registerCommand("verbatim:font", function (options, content)
+  self:registerCommand("verbatim:font", function (options, content)
     options.size = options.size or "0.86em"
     SILE.call("cabook:font:mono", options, content)
   end)
 
 end
 
-return {
-  registerCommands = registerCommands
-}
+return package

--- a/packages/covers.lua
+++ b/packages/covers.lua
@@ -1,8 +1,13 @@
+local base = require("packages.base")
+
+local package = pl.class(base)
+package._name = "covers"
+
 local color = "#FFFFFF"
 
-local function registerCommands (_)
+function package:registerCommands ()
 
-  SILE.registerCommand("frontcover", function ()
+  self:registerCommand("frontcover", function ()
     local options = {}
     options["first-content-frame"] = "front"
     SILE.call("pagetemplate", options, function ()
@@ -37,7 +42,7 @@ local function registerCommands (_)
     end)
   end)
 
-  SILE.registerCommand("backcover", function ()
+  self:registerCommand("backcover", function ()
     local options = {}
     options["first-content-frame"] = "front"
     SILE.call("pagetemplate", options, function ()
@@ -82,7 +87,7 @@ local function registerCommands (_)
     end)
   end)
 
-  SILE.registerCommand("spine", function (options)
+  self:registerCommand("spine", function (options)
     options["first-content-frame"] = "spine1"
     SILE.call("pagetemplate", options, function ()
       SILE.call("frame", {
@@ -127,6 +132,4 @@ local function registerCommands (_)
 
 end
 
-return {
-  registerCommands = registerCommands
-}
+return package

--- a/packages/crop.lua
+++ b/packages/crop.lua
@@ -1,3 +1,8 @@
+local base = require("packages.base")
+
+local package = pl.class(base)
+package._name = "crop"
+
 local bleed = 3 * 2.83465
 local trim = 10 * 2.83465
 local len = trim - bleed
@@ -24,7 +29,7 @@ local function reconstrainFrameset(fs)
   end
 end
 
-local setupCrop = function (_, args)
+function package:setupCrop (args)
   if args then
     bleed = args.bleed or bleed
     trim = args.trim or trim
@@ -50,7 +55,7 @@ local setupCrop = function (_, args)
   if SILE.typesetter and SILE.typesetter.frame then SILE.typesetter.frame:init() end
 end
 
-local outputMarks = function ()
+function package:outputCropMarks ()
   local page = SILE.getFrame("page")
 
   -- Top left
@@ -88,28 +93,22 @@ local outputMarks = function ()
   end
 end
 
-local function init (class, args)
+function package:_init (args)
+  base._init(self, args)
 
   outcounter = 1
-  cropbinding = class.options.binding == "stapled"
-  setupCrop(args)
+  cropbinding = self.class.options.binding == "stapled"
+  self:setupCrop(args)
 
 end
 
-local function registerCommands (_)
+function package:registerCommands ()
 
-  SILE.registerCommand("crop:header", function (_, _)
+  self:registerCommand("crop:header", function (_, _)
     SILE.call("meta:surum")
     SILE.typesetter:typeset(" (" .. outcounter .. ") " .. os.getenv("HOSTNAME") .. " / " .. os.date("%Y-%m-%d, %X"))
   end)
 
 end
 
-return {
-  init = init,
-  registerCommands = registerCommands,
-  exports =  {
-    outputCropMarks = outputMarks,
-    setupCrop = setupCrop
-  }
-}
+return package

--- a/packages/crop.lua
+++ b/packages/crop.lua
@@ -9,7 +9,7 @@ local len = trim - bleed
 
 local outcounter, cropbinding
 
-local function reconstrainFrameset(fs)
+local function reconstrainFrameset (fs)
   for n,f in pairs(fs) do
     if n ~= "page" then
       if f:isAbsoluteConstraint("right") then
@@ -29,7 +29,7 @@ local function reconstrainFrameset(fs)
   end
 end
 
-function package:setupCrop (args)
+local function _setupCrop (args)
   if args then
     bleed = args.bleed or bleed
     trim = args.trim or trim
@@ -55,7 +55,7 @@ function package:setupCrop (args)
   if SILE.typesetter and SILE.typesetter.frame then SILE.typesetter.frame:init() end
 end
 
-function package:outputCropMarks ()
+local function _outputCropMarks ()
   local page = SILE.getFrame("page")
 
   -- Top left
@@ -98,7 +98,9 @@ function package:_init (args)
 
   outcounter = 1
   cropbinding = self.class.options.binding == "stapled"
-  self:setupCrop(args)
+  _setupCrop(args)
+
+  self.class:registerHook("endpage", _outputCropMarks)
 
 end
 

--- a/packages/imprint.lua
+++ b/packages/imprint.lua
@@ -1,10 +1,16 @@
-local function init (class, _)
-  class:loadPackage("markdown")
+local base = require("packages.base")
+
+local package = pl.class(base)
+package._name = "imprint"
+
+function package:_init ()
+  base._init(self)
+  self.class:loadPackage("markdown")
 end
 
-local function registerCommands (_)
+function package:registerCommands ()
 
-  SILE.registerCommand("imprint:font", function (options, content)
+  self:registerCommand("imprint:font", function (options, content)
     options.weight = options.weight or 400
     options.size = options.size or "9pt"
     options.language = options.language or "und"
@@ -12,7 +18,7 @@ local function registerCommands (_)
     SILE.call("font", options, content)
   end)
 
-  SILE.registerCommand("imprint", function (_, _)
+  self:registerCommand("imprint", function (_, _)
     SILE.settings:temporarily(function ()
       local imgUnit = SILE.length("1em")
       SILE.settings:set("document.lskip", SILE.nodefactory.glue())
@@ -115,7 +121,7 @@ local function registerCommands (_)
     SILE.call("break")
   end)
 
-  SILE.registerCommand("meta:distribution", function (_, _)
+  self:registerCommand("meta:distribution", function (_, _)
     local layout = CASILE.layout
     local distros = CASILE.metadata.distribution
     local text = nil
@@ -136,7 +142,4 @@ local function registerCommands (_)
 
 end
 
-return {
-  init = init,
-  registerCommands = registerCommands
-}
+return package

--- a/packages/lists.lua
+++ b/packages/lists.lua
@@ -13,7 +13,7 @@ function package:_init ()
   SILE.scratch.liststyle = nil
 end
 
-local function registerCommands (_)
+function package:registerCommands ()
 
   self:registerCommand("listarea", function (options, content)
     nestedlist = nestedlist + 1

--- a/packages/lists.lua
+++ b/packages/lists.lua
@@ -1,15 +1,21 @@
+local base = require("packages.base")
+
+local package = pl.class(base)
+package._name = "lists"
+
 local nestedlist = 0
 local liststyles = {}
 local listarealskip = nil
 
-local function init (class, _)
-  class:loadPackage("counters")
+function package:_init ()
+  base._init(self)
+  self.class:loadPackage("counters")
   SILE.scratch.liststyle = nil
 end
 
 local function registerCommands (_)
 
-  SILE.registerCommand("listarea", function (options, content)
+  self:registerCommand("listarea", function (options, content)
     nestedlist = nestedlist + 1
     if nestedlist == 1 then listarealskip = SILE.settings:get("document.parindent").width end
     liststyles[nestedlist] = { options.numberstyle }
@@ -25,7 +31,7 @@ local function registerCommands (_)
     nestedlist = nestedlist - 1
   end)
 
-  SILE.registerCommand("listitem", function (_, content)
+  self:registerCommand("listitem", function (_, content)
     local markerwidth = SILE.length("1.5em")
     SILE.call("kern", { width = tostring(markerwidth:negate()) })
     SILE.call("rebox", { width = tostring(markerwidth) }, function ()
@@ -43,7 +49,4 @@ local function registerCommands (_)
 
 end
 
-return {
-  init = init,
-  registerCommands = registerCommands
-}
+return package

--- a/packages/markdown.lua
+++ b/packages/markdown.lua
@@ -1,17 +1,33 @@
-SILE.processMarkdown = function (content, callback)
-  callback = callback or function (...) return ... end
-  local lunamark = require("lunamark")
-  local reader = lunamark.reader.markdown
-  local writer = lunamark.writer.ast.new()
-  local parse = reader.new(writer)
-  local output = callback(parse(tostring(content[1])))
-  SILE.process(output)
+local base = require("packages.base")
+
+local package = pl.class(base)
+package._name = "markdown"
+
+function package:_init ()
+  base._init(self)
+
+  SILE.processMarkdown = function (content, callback)
+    callback = callback or function (...) return ... end
+    local lunamark = require("lunamark")
+    local reader = lunamark.reader.markdown
+    local writer = lunamark.writer.ast.new()
+    local parse = reader.new(writer)
+    local output = callback(parse(tostring(content[1])))
+    SILE.process(output)
+  end
+
 end
 
-SILE.registerCommand("processMarkdown", function (options, content)
-  SILE.processMarkdown(SU.contentToString(content), options.callback)
-end)
+function package:registerCommands ()
 
-SILE.registerCommand("emphasis", function (options, content)
-  SILE.call("em", options, content)
-end)
+  self:registerCommand("processMarkdown", function (options, content)
+    SILE.processMarkdown(SU.contentToString(content), options.callback)
+  end)
+
+  self:registerCommand("emphasis", function (options, content)
+    SILE.call("em", options, content)
+  end)
+
+end
+
+return package

--- a/packages/verseindex.lua
+++ b/packages/verseindex.lua
@@ -1,17 +1,23 @@
+local base = require("packages.base")
+
+local package = pl.class(base)
+package._name = "verseindex"
+
+
 SILE.require("packages/url")
 
 SILE.scratch.tableofverses = {}
 
 local orig_href = SILE.Commands["href"]
 
-local writeTov = function (_)
+function package:writeTov ()
   local contents = "return " .. std.string.pickle(SILE.scratch.tableofverses)
   local tovfile, err = io.open(SILE.masterFilename .. '.tov', "w")
   if not tovfile then return SU.error(err) end
   tovfile:write(contents)
 end
 
-local moveNodes = function (_)
+function package:moveTovNodes ()
   local node = SILE.scratch.info.thispage.tov
   if node then
     for i = 1, #node do
@@ -21,14 +27,15 @@ local moveNodes = function (_)
   end
 end
 
-local init = function (self)
+local inpair = nil
+local repairbreak = function () end
+local defaultparskip = SILE.settings:get("typesetter.parfillskip")
 
-  self:loadPackage("infonode")
-  self:loadPackage("leaders")
+function package:_init ()
+  base._init(self)
 
-  local inpair = nil
-  local repairbreak = function () end
-  local defaultparskip = SILE.settings:get("typesetter.parfillskip")
+  self.class:loadPackage("infonode")
+  self.class:loadPackage("leaders")
 
   local continuepair = function (args)
     if not args then return end
@@ -47,6 +54,10 @@ local init = function (self)
     repairbreak()
   end
 
+end
+
+function package:registerCommands ()
+
   local startpair = function (pair)
     -- Temporarily disable columns pending upstream bugfix
     -- https://github.com/sile-typesetter/sile/issues/891
@@ -61,12 +72,12 @@ local init = function (self)
     SILE.settings:set("typesetter.parfillskip", defaultparskip)
   end
 
-  SILE.registerCommand("href", function (options, content)
+  self:registerCommand("href", function (options, content)
     SILE.call("markverse", options, content)
     return orig_href(options, content)
   end)
 
-  SILE.registerCommand("tableofverses:book", function (_, content)
+  self:registerCommand("tableofverses:book", function (_, content)
     SILE.call("requireSpace", { height = "4em" })
     SILE.settings:set("typesetter.parfillskip", defaultparskip)
     SILE.call("hbox")
@@ -76,7 +87,7 @@ local init = function (self)
     startpair(content[1])
   end)
 
-  SILE.registerCommand("tableofverses:reference", function (options, content)
+  self:registerCommand("tableofverses:reference", function (options, content)
     if #options.pages < 1 then
       SU.warn("Verse in index doesn't have page marker")
       options.pages = { "0" }
@@ -97,7 +108,7 @@ local init = function (self)
     SILE.call("par")
   end)
 
-  SILE.registerCommand("markverse", function (options, content)
+  self:registerCommand("markverse", function (options, content)
     SILE.typesetter:typeset("​") -- Protect hbox location from getting discarded
     SILE.call("info", {
         category = "tov",
@@ -108,7 +119,7 @@ local init = function (self)
       })
   end)
 
-  SILE.registerCommand("tableofverses", function (_, _)
+  self:registerCommand("tableofverses", function (_, _)
     SILE.call("chapter", { numbering = false, appendix = true }, { "Ayet Referans İndeksi" })
     SILE.call("cabook:font:serif", { size = "0.95em" })
     local origmethod = SILE.settings:get("linespacing.method")
@@ -157,10 +168,4 @@ local init = function (self)
 
 end
 
-return {
-  exports = {
-    writeTov = writeTov,
-    moveTovNodes = moveNodes
-  },
-  init = init
-}
+return package

--- a/packages/verseindex.lua
+++ b/packages/verseindex.lua
@@ -10,14 +10,14 @@ SILE.scratch.tableofverses = {}
 
 local orig_href = SILE.Commands["href"]
 
-function package:writeTov ()
+local function _writeTov ()
   local contents = "return " .. std.string.pickle(SILE.scratch.tableofverses)
   local tovfile, err = io.open(SILE.masterFilename .. '.tov', "w")
   if not tovfile then return SU.error(err) end
   tovfile:write(contents)
 end
 
-function package:moveTovNodes ()
+local function _moveTovNodes ()
   local node = SILE.scratch.info.thispage.tov
   if node then
     for i = 1, #node do
@@ -53,6 +53,12 @@ function package:_init ()
     pushBack(current_typesetter)
     repairbreak()
   end
+
+  self.class:registerHook("endpage", _moveTovNodes)
+  self.class:registerHook("finish", _writeTov)
+  self.class:registerHook("finish", function ()
+    SILE.call("tableofverses")
+  end)
 
 end
 

--- a/packages/verseindex.lua
+++ b/packages/verseindex.lua
@@ -11,7 +11,7 @@ SILE.scratch.tableofverses = {}
 local orig_href = SILE.Commands["href"]
 
 local function _writeTov ()
-  local contents = "return " .. std.string.pickle(SILE.scratch.tableofverses)
+  local contents = "return " .. pl.pretty.write(SILE.scratch.tableofverses)
   local tovfile, err = io.open(SILE.masterFilename .. '.tov', "w")
   if not tovfile then return SU.error(err) end
   tovfile:write(contents)


### PR DESCRIPTION
The last release just covered some very basic mistakes so that projects could keep going with SILE v0.14. It relied heavily on SILE's shims and deprecated functions. This starts chipping away at the task of actually making use of new ones.

Notably this doesn't deal with the mess of Lua injections CaSILE has hacked in with `-I`.
